### PR TITLE
[Feat] User 엔티티 생성

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/user/model/User.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/model/User.kt
@@ -1,0 +1,36 @@
+package com.example.sanrio.domain.user.model
+
+import com.example.sanrio.global.model.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "users")
+class User(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    val status: UserStatus = UserStatus.NEW,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    val role: UserRole = UserRole.USER,
+
+    @Column(name = "email", nullable = false, unique = true)
+    val email: String,
+
+    @Column(name = "password", nullable = false)
+    val password: String,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "nickname", nullable = false, unique = true)
+    val nickname: String,
+
+    @Column(name = "address", nullable = false)
+    val address: String?
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id", nullable = false, unique = true)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/example/sanrio/domain/user/model/UserRole.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/model/UserRole.kt
@@ -1,0 +1,5 @@
+package com.example.sanrio.domain.user.model
+
+enum class UserRole {
+    USER, ADMIN
+}

--- a/src/main/kotlin/com/example/sanrio/domain/user/model/UserStatus.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/model/UserStatus.kt
@@ -1,0 +1,5 @@
+package com.example.sanrio.domain.user.model
+
+enum class UserStatus {
+    NEW, NORMAL, WITHDRAWN
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #3

## 작업 내용

- [ ] User 엔티티 생성 -> id, status, role, email, password, name, nickname, address
- [ ] User 엔티티는 BaseEntity를 상속받음
- [ ] User의 status를 저장할 UserStatus enum 클래스 생성 -> NEW, NORMAL, WITHDRAWN
- [ ] User의 role을 저장할 UserRole enum 클래스 생성 -> USER, ADMIN

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
