### PR TITLE
[Feat] Product 엔티티 생성

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/product/model/Product.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/model/Product.kt
@@ -1,0 +1,31 @@
+package com.example.sanrio.domain.product.model
+
+import com.example.sanrio.domain.character.model.Character
+import com.example.sanrio.global.model.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "products")
+class Product(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    val status: ProductStatus = ProductStatus.SALE,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "detail", nullable = false)
+    val detail: String,
+
+    @Column(name = "stock", nullable = false)
+    val stock: Int,
+
+    @ManyToOne
+    @JoinColumn(name = "character_id", nullable = false)
+    val character: Character
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id", nullable = false, unique = true)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/example/sanrio/domain/product/model/ProductStatus.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/model/ProductStatus.kt
@@ -1,0 +1,5 @@
+package com.example.sanrio.domain.product.model
+
+enum class ProductStatus {
+    SALE, SOLD_OUT
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #29 

## 작업 내용

- [x] Product 엔티티 생성 -> id, status, name, detail, stock
- [x] Product의 status를 저장할 ProductStatus enum 클래스 생성 -> SALE< SOLD_OUT
- [x] Product와 Character는 다대일 연관관계를 가진다.

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
