### PR TITLE
[Settings] QueryDSL을 사용하기 위한 기본 세팅

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("plugin.jpa") version "1.9.24"
     kotlin("jvm") version "1.9.24"
     kotlin("plugin.spring") version "1.9.24"
+    kotlin("kapt") version "2.0.0" // QUERYDSL
 }
 
 group = "com.example"
@@ -23,6 +24,9 @@ dependencies {
     // DB
     runtimeOnly("com.h2database:h2")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    // QUERYDSL
+    implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
     // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/com/example/sanrio/domain/product/dto/response/ProductResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/dto/response/ProductResponse.kt
@@ -1,0 +1,9 @@
+package com.example.sanrio.domain.product.dto.response
+
+import java.time.LocalDateTime
+
+data class ProductResponse(
+    val productId: Long,
+    val name: String,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepository.kt
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface ProductRepository : JpaRepository<Product, Long>
+interface ProductRepository : JpaRepository<Product, Long>, ProductRepositoryCustom

--- a/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryCustom.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryCustom.kt
@@ -1,0 +1,11 @@
+package com.example.sanrio.domain.product.repository
+
+import com.example.sanrio.domain.product.dto.response.ProductResponse
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProductRepositoryCustom {
+    fun getProducts(pageable: Pageable): Page<ProductResponse>
+}

--- a/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.example.sanrio.domain.product.repository
+
+import com.example.sanrio.domain.product.dto.response.ProductResponse
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+
+@Repository
+class ProductRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): ProductRepositoryCustom {
+    override fun getProducts(pageable: Pageable): Page<ProductResponse> {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/example/sanrio/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/example/sanrio/global/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package com.example.sanrio.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig {
+    @PersistenceContext
+    protected lateinit var em: EntityManager
+
+    @Bean
+    protected fun jpaQueryFactory() = JPAQueryFactory(em)
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #39 

## 작업 내용

- [x] build.gradle에 kapt 플러그인 추가 및 QueryDSL 관련 의존성 추입
- [x] JPAQueryFactory을 Bean에 등록하기 위한 QueryDslConfig 클래스 추가
- [x] QueryDSL을 사용하기 위한 Product 관련 2개의 추가적인 Repository 생성 -> ProductRepositoryCustom, ProductRepositoryImpl
- [x] 보여주고자 하는 상품 기본 정보를 담은 ProductResponse DTO 클래스 생성 -> productId, name, createdAt

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
