### PR TITLE
[Feat] 상품 목록 조회 기능 구현

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/product/controller/ProductController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/controller/ProductController.kt
@@ -1,6 +1,8 @@
 package com.example.sanrio.domain.product.controller
 
 import com.example.sanrio.domain.product.dto.request.AddProductRequest
+import com.example.sanrio.domain.product.dto.response.ProductSortCondition
+import com.example.sanrio.domain.product.model.ProductStatus
 import com.example.sanrio.domain.product.service.ProductService
 import jakarta.validation.Valid
 import org.springframework.context.annotation.Description
@@ -23,4 +25,14 @@ class ProductController(
     fun getProduct(
         @PathVariable productId: Long
     ) = ResponseEntity.ok().body(productService.getProduct(productId = productId))
+
+    @Description("상품 목록")
+    @GetMapping
+    fun getProducts(
+        @RequestParam(required = false) status: ProductStatus?, // 필터 조건
+        @RequestParam(required = false) sort: ProductSortCondition?, // 정렬 조건
+        @RequestParam(defaultValue = "1") page: Int
+    ) =
+        productService.getProducts(page = page, status = status, sort = sort)
+            .let { ResponseEntity.ok().body(it) }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/product/dto/response/ProductPageResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/dto/response/ProductPageResponse.kt
@@ -1,0 +1,19 @@
+package com.example.sanrio.domain.product.dto.response
+
+import org.springframework.data.domain.Page
+
+data class ProductPageResponse(
+    val totalElements: Long,
+    val totalPages: Int,
+    val size: Int,
+    val content: List<ProductResponse>
+) {
+    companion object {
+        fun from(page: Page<ProductResponse>) = ProductPageResponse(
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
+            size = page.size,
+            content = page.content
+        )
+    }
+}

--- a/src/main/kotlin/com/example/sanrio/domain/product/dto/response/ProductSortCondition.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/dto/response/ProductSortCondition.kt
@@ -1,0 +1,5 @@
+package com.example.sanrio.domain.product.dto.response
+
+enum class ProductSortCondition {
+    HIGH_PRICE, LOW_PRICE, CREATED_AT
+}

--- a/src/main/kotlin/com/example/sanrio/domain/product/model/ProductStatus.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/model/ProductStatus.kt
@@ -1,5 +1,17 @@
 package com.example.sanrio.domain.product.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import org.apache.commons.lang3.EnumUtils
+import org.springframework.context.annotation.Description
+
 enum class ProductStatus {
-    SALE, SOLD_OUT
+    SALE, SOLD_OUT;
+
+    companion object {
+        @Description("JSON으로 입력받은 문자열을 파싱하여 ProductStatus로 변환")
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(name: String?): ProductStatus? =
+            name?.let { EnumUtils.getEnumIgnoreCase(ProductStatus::class.java, it.trim()) }
+    }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryCustom.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryCustom.kt
@@ -1,11 +1,13 @@
 package com.example.sanrio.domain.product.repository
 
 import com.example.sanrio.domain.product.dto.response.ProductResponse
+import com.example.sanrio.domain.product.dto.response.ProductSortCondition
+import com.example.sanrio.domain.product.model.ProductStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
 interface ProductRepositoryCustom {
-    fun getProducts(pageable: Pageable): Page<ProductResponse>
+    fun getProducts(pageable: Pageable, status: ProductStatus?, sort: ProductSortCondition?): Page<ProductResponse>
 }

--- a/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/repository/ProductRepositoryImpl.kt
@@ -1,16 +1,68 @@
 package com.example.sanrio.domain.product.repository
 
 import com.example.sanrio.domain.product.dto.response.ProductResponse
+import com.example.sanrio.domain.product.dto.response.ProductSortCondition
+import com.example.sanrio.domain.product.model.ProductStatus
+import com.example.sanrio.domain.product.model.QProduct
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
-import org.springframework.data.domain.Page
+import org.springframework.context.annotation.Description
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
 class ProductRepositoryImpl(
     private val jpaQueryFactory: JPAQueryFactory
-): ProductRepositoryCustom {
-    override fun getProducts(pageable: Pageable): Page<ProductResponse> {
-        TODO("Not yet implemented")
-    }
+) : ProductRepositoryCustom {
+    private val product = QProduct.product
+
+    @Description("상품 목록을 조회하는 메서드")
+    override fun getProducts(pageable: Pageable, status: ProductStatus?, sort: ProductSortCondition?) =
+        BooleanBuilder().let {
+            status?.let { status -> it.and(product.status.eq(status)) }
+        }.let {
+            PageImpl(
+                getContents(
+                    pageable = pageable,
+                    whereClause = it ?: BooleanBuilder(),
+                    sort = getOrderCondition(sort = sort, product = product)
+                ),
+                pageable,
+                getTotalElements()
+            )
+        }
+
+    @Description("페이지에 포함될 상품 데이터를 가져오는 내부 메서드")
+    private fun getContents(pageable: Pageable, whereClause: BooleanBuilder, sort: OrderSpecifier<*>) =
+        jpaQueryFactory.select(
+            Projections.constructor(
+                ProductResponse::class.java,
+                product.id,
+                product.status,
+                product.name,
+                product.price,
+                product.character.name,
+                product.createdAt
+            )
+        ).from(product)
+            .where(whereClause)
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .orderBy(sort)
+            .fetch()
+
+    @Description("전체 상품 개수를 가져오는 내부 메서드")
+    private fun getTotalElements() =
+        jpaQueryFactory.select(product.count()).from(product).fetchOne() ?: 0L
+
+    @Description("정렬 조건을 판단하는 내부 메서드")
+    private fun getOrderCondition(sort: ProductSortCondition?, product: QProduct) =
+        when (sort) {
+            ProductSortCondition.HIGH_PRICE -> product.price.desc()
+            ProductSortCondition.LOW_PRICE -> product.price.asc()
+            else -> product.id.desc()
+        }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/product/service/ProductService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/service/ProductService.kt
@@ -3,9 +3,13 @@ package com.example.sanrio.domain.product.service
 import com.example.sanrio.domain.character.repository.CharacterRepository
 import com.example.sanrio.domain.product.dto.request.AddProductRequest
 import com.example.sanrio.domain.product.dto.response.ProductDetailResponse
+import com.example.sanrio.domain.product.dto.response.ProductPageResponse
+import com.example.sanrio.domain.product.dto.response.ProductSortCondition
+import com.example.sanrio.domain.product.model.ProductStatus
 import com.example.sanrio.domain.product.repository.ProductRepository
 import com.example.sanrio.global.exception.case.ModelNotFoundException
 import org.springframework.context.annotation.Description
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
@@ -33,4 +37,14 @@ class ProductService(
     fun getProduct(productId: Long) =
         findProductById(productId = productId)
             .let { ProductDetailResponse.from(product = it) }
+
+    @Description("상품 목록")
+    fun getProducts(page: Int, status: ProductStatus?, sort: ProductSortCondition?) =
+        PageRequest.of(page - 1, PRODUCT_PAGE_SIZE)
+            .let { productRepository.getProducts(pageable = it, status = status, sort = sort) }
+            .let { ProductPageResponse.from(page = it) }
+
+    companion object {
+        private const val PRODUCT_PAGE_SIZE = 6
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #47 

## 작업 내용

- [x] ProductService와 ProductController에 getProducts 메서드 생성
- [x] ProductStatus에 JSON 문자열을 enum 클래스로 변환하는 parse 메서드 생성
- [x] 정렬 조건들을 담은 ProductSortCondition enum 클래스 생성
- [x] ProductRepositoryImpl에 getProducts 메서드 구현
- [x] 상품 정보와 함께 페이지 정보를 담은 ProductPageResponse DTO 클래스 생성 -> totalElements, totalPages, size, content

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
