### PR TITLE
[Feat] Cart, CartItem 엔티티 생성

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/cart/model/Cart.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/model/Cart.kt
@@ -1,0 +1,18 @@
+package com.example.sanrio.domain.cart.model
+
+import com.example.sanrio.domain.user.model.User
+import com.example.sanrio.global.model.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "carts")
+class Cart(
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    val user: User
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cart_id", nullable = false)
+    var id: Long? = null
+}

--- a/src/main/kotlin/com/example/sanrio/domain/cart/model/CartItem.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/model/CartItem.kt
@@ -1,0 +1,25 @@
+package com.example.sanrio.domain.cart.model
+
+import com.example.sanrio.domain.product.model.Product
+import com.example.sanrio.global.model.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "cart_items")
+class CartItem(
+    @Column(name = "count", nullable = false)
+    val count: Int,
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    val product: Product,
+
+    @ManyToOne
+    @JoinColumn(name = "cart_id", nullable = false)
+    val cart: Cart
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cart_item_id", nullable = false, unique = true)
+    var id: Long? = null
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #61 

## 작업 내용

- [x] Cart, CartItem 엔티티 생성
- [x] Cart와 Product는 다대다 관계이므로, 중간 엔티티인 CartItem을 만들어 각 엔티티와 다대일 관계를 갖는다.
- [x] Cart와 User는 일대일 관계를 갖는다.
- [x] UserService에 회원가입이 완료되면 해당 유저 소유의 장바구니가 1개 만들어지는 로직 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
