### PR TITLE
[Feat] ItemException 생성 및 하위 2개의 에러 케이스 추가

### DIFF
--- a/src/main/kotlin/com/example/sanrio/global/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/example/sanrio/global/exception/ExceptionHandler.kt
@@ -1,9 +1,6 @@
 package com.example.sanrio.global.exception
 
-import com.example.sanrio.global.exception.case.DuplicatedValueException
-import com.example.sanrio.global.exception.case.InvalidValueException
-import com.example.sanrio.global.exception.case.LoginException
-import com.example.sanrio.global.exception.case.ModelNotFoundException
+import com.example.sanrio.global.exception.case.*
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -40,5 +37,11 @@ class ExceptionHandler {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(LoginException::class)
     fun handleLoginException(e: LoginException) =
+        ErrorResponse(message = e.message!!, statusCode = "400 Bad Request")
+
+    // 상품 주문 관련 에러 장바구니 추가 혹은 상품 주문 시 재고를 초과하는 수량을 주문한 경우
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ItemException::class)
+    fun handleOutOfStockException(e: ItemException) =
         ErrorResponse(message = e.message!!, statusCode = "400 Bad Request")
 }

--- a/src/main/kotlin/com/example/sanrio/global/exception/case/ItemException.kt
+++ b/src/main/kotlin/com/example/sanrio/global/exception/case/ItemException.kt
@@ -1,0 +1,3 @@
+package com.example.sanrio.global.exception.case
+
+open class ItemException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/example/sanrio/global/exception/case/OutOfStockException.kt
+++ b/src/main/kotlin/com/example/sanrio/global/exception/case/OutOfStockException.kt
@@ -1,0 +1,3 @@
+package com.example.sanrio.global.exception.case
+
+class OutOfStockException(stock: Int) : ItemException("상품 재고가 부족합니다. 현재 잔여 수량은 ${stock}개입니다.")

--- a/src/main/kotlin/com/example/sanrio/global/exception/case/TooManyItemsException.kt
+++ b/src/main/kotlin/com/example/sanrio/global/exception/case/TooManyItemsException.kt
@@ -1,0 +1,3 @@
+package com.example.sanrio.global.exception.case
+
+class TooManyItemsException : ItemException("최대 5개의 상품만 주문할 수 있습니다.")


### PR DESCRIPTION
## 연관된 이슈

- closes #65 

## 작업 내용

- [x] 장바구니 속 상품과 관련된 모든 Exception들의 상위 클래스인 ItemException 생성 후, ExceptionHandler에 추가
- [x] TooManyItemsException(6개 이상의 상품을 주문한 경우) 생성
- [x] OutOfStockException(재고보다 더 많은 수량의 상품을 주문한 경우) 생성

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
