### PR TITLE
[Feat] Cart 엔티티에 totalPrice 필드 추가

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/cart/controller/CartController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/controller/CartController.kt
@@ -1,6 +1,6 @@
 package com.example.sanrio.domain.cart.controller
 
-import com.example.sanrio.domain.cart.CartService
+import com.example.sanrio.domain.cart.service.CartService
 import org.springframework.context.annotation.Description
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/com/example/sanrio/domain/cart/dto/response/CartItemResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/dto/response/CartItemResponse.kt
@@ -6,6 +6,6 @@ data class CartItemResponse(
     val productId: Long,
     val productStatus: ProductStatus,
     val productName: String,
-    val productTotalPrice: Int,
+    val productUnitPrice: Int,
     val count: Int
 )

--- a/src/main/kotlin/com/example/sanrio/domain/cart/dto/response/CartResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/dto/response/CartResponse.kt
@@ -1,0 +1,17 @@
+package com.example.sanrio.domain.cart.dto.response
+
+import com.example.sanrio.domain.cart.model.Cart
+
+data class CartResponse(
+    val userId: Long,
+    val totalPrice: Int,
+    val cartItems: List<CartItemResponse>
+) {
+    companion object {
+        fun from(cart: Cart, cartItems: List<CartItemResponse>) = CartResponse(
+            userId = cart.user.id!!,
+            totalPrice = cart.totalPrice,
+            cartItems = cartItems
+        )
+    }
+}

--- a/src/main/kotlin/com/example/sanrio/domain/cart/model/Cart.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/model/Cart.kt
@@ -3,10 +3,14 @@ package com.example.sanrio.domain.cart.model
 import com.example.sanrio.domain.user.model.User
 import com.example.sanrio.global.model.BaseEntity
 import jakarta.persistence.*
+import org.springframework.context.annotation.Description
 
 @Entity
 @Table(name = "carts")
 class Cart(
+    @Column(name = "total_price", nullable = false)
+    var totalPrice: Int = 0,
+
     @OneToOne
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     val user: User
@@ -15,4 +19,9 @@ class Cart(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cart_id", nullable = false)
     var id: Long? = null
+
+    @Description("전체 수량(totalPrice) 업데이트")
+    fun updateTotalPrice(unitPrice: Int) {
+        this.totalPrice += unitPrice
+    }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/cart/model/CartItem.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/model/CartItem.kt
@@ -11,8 +11,8 @@ class CartItem(
     @Column(name = "count", nullable = false)
     var count: Int,
 
-    @Column(name = "total_price", nullable = false)
-    var totalPrice: Int,
+    @Column(name = "unit_price", nullable = false)
+    var unitPrice: Int,
 
     @ManyToOne
     @JoinColumn(name = "product_id", nullable = false)
@@ -30,6 +30,6 @@ class CartItem(
     @Description("수량 변경")
     fun updateCount(count: Int) {
         this.count = count
-        this.totalPrice = this.product.price * count
+        this.unitPrice = this.product.price * count
     }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/cart/repository/CartItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/cart/repository/CartItemRepositoryImpl.kt
@@ -21,11 +21,11 @@ class CartItemRepositoryImpl(
                 cartItem.product.id,
                 cartItem.product.status,
                 cartItem.product.name,
-                cartItem.totalPrice,
+                cartItem.unitPrice,
                 cartItem.count
             )
         ).from(cartItem)
             .where(BooleanBuilder(cartItem.cart.eq(cart)))
-            .orderBy(cartItem.id.desc())
+            .orderBy(cartItem.updatedAt.desc())
             .fetch()
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #91

## 작업 내용

- [x] Cart 엔티티에 totalPrice 필드 추가
- [x] 기존의 CartItem 엔티티의 totalPrice 필드명을 unitPrice로 변경
- [x] CartService에 장바구니에 상품을 추가/수량 수정 할때마다 totalPrice를 계산하여 변경하는 로직 추가
- [x] 장바구니 조회시 관련 정보를 담을 CartResponse DTO 클래스 생성 -> userId, totalPrice, 기존의 CartItemResponse 리스트
- [x] 장바구니 조회시 정렬 조건을 updatedAt 내림차순으로 변경

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
