### PR TITLE
[Feat] Order, OrderItem 생성

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
@@ -1,0 +1,28 @@
+package com.example.sanrio.domain.order.model
+
+import com.example.sanrio.domain.user.model.User
+import com.example.sanrio.global.model.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "orders")
+class Order(
+    @Column(name = "code", nullable = false)
+    val code: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    val status: OrderStatus = OrderStatus.PAID,
+
+    @Column(name = "total_price", nullable = false)
+    val totalPrice: Int = 0,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id", nullable = false, unique = true)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/model/OrderItem.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/OrderItem.kt
@@ -1,0 +1,24 @@
+package com.example.sanrio.domain.order.model
+
+import com.example.sanrio.domain.product.model.Product
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "order_items")
+class OrderItem(
+    @Column(name = "count", nullable = false)
+    val count: Int,
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    val product: Product,
+
+    @ManyToOne
+    @JoinColumn(name = "order_id", nullable = false)
+    val order: Order
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_item_id", nullable = false, unique = true)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/model/OrderStatus.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/OrderStatus.kt
@@ -1,0 +1,5 @@
+package com.example.sanrio.domain.order.model
+
+enum class OrderStatus {
+    CANCELLED, PAID, SHIPPING, DELIVERED, REQUESTED_FOR_RECALL, RECALLED
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #95 

## 작업 내용

- [x] Order, OrderItem 엔티티 생성
- [x] Order와 Product는 다대다 관계이므로, 중간 엔티티인 OrderItem을 만들어 각 엔티티와 다대일 관계를 갖는다.
- [x] Order와 User는 다대일 관계를 갖는다.
- [x] 주문 상태를 표현하는 OrderStatus enum 클래스를 생성

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
