### PR TITLE
[Feat] Address와 User를 다대일 관계로 수정

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/controller/UserController.kt
@@ -3,6 +3,7 @@ package com.example.sanrio.domain.user.controller
 import com.example.sanrio.domain.user.dto.request.AddressRequest
 import com.example.sanrio.domain.user.dto.request.LoginRequest
 import com.example.sanrio.domain.user.dto.request.SignUpRequest
+import com.example.sanrio.domain.user.service.AddressService
 import com.example.sanrio.domain.user.service.UserService
 import jakarta.validation.Valid
 import org.springframework.context.annotation.Description
@@ -11,7 +12,8 @@ import org.springframework.web.bind.annotation.*
 
 @RestController
 class UserController(
-    private val userService: UserService
+    private val userService: UserService,
+    private val addressService: AddressService
 ) {
     @Description("일반 유저 회원가입")
     @PostMapping("/signup")
@@ -47,5 +49,5 @@ class UserController(
     fun setAddress(
         @PathVariable userId: Long,
         @Valid @RequestBody request: AddressRequest
-    ) = ResponseEntity.ok().body(userService.setAddress(userId = userId, request = request))
+    ) = ResponseEntity.ok().body(addressService.setAddress(userId = userId, request = request))
 }

--- a/src/main/kotlin/com/example/sanrio/domain/user/dto/request/AddressRequest.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/dto/request/AddressRequest.kt
@@ -15,10 +15,11 @@ data class AddressRequest(
     @field:NotBlank(message = "세부 주소를 입력해주세요.")
     val detailAddress: String?
 ) {
-    fun to(user: User, encryptor: Encryptor) = Address(
+    fun to(user: User, encryptor: Encryptor, isFirstAddress: Boolean = false) = Address(
         zipCode = this.zipCode!!,
         streetAddress = this.streetAddress!!,
         detailAddress = encryptor.encrypt(this.detailAddress!!),
-        user = user
+        user = user,
+        default = isFirstAddress
     )
 }

--- a/src/main/kotlin/com/example/sanrio/domain/user/dto/request/SignUpRequest.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/dto/request/SignUpRequest.kt
@@ -31,7 +31,6 @@ data class SignUpRequest(
         email = this.email,
         password = passwordEncoder.encode(this.password),
         name = this.name,
-        nickname = generateNickname(),
-        address = null
+        nickname = generateNickname()
     )
 }

--- a/src/main/kotlin/com/example/sanrio/domain/user/model/Address.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/model/Address.kt
@@ -19,8 +19,11 @@ class Address(
     @Column(name = "detail_address", nullable = false)
     var detailAddress: ByteArray,
 
-    @OneToOne
-    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @Column(name = "is_selected", nullable = false)
+    var default: Boolean,
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
     val user: User
 ) : BaseEntity() {
     @Id

--- a/src/main/kotlin/com/example/sanrio/domain/user/model/User.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/model/User.kt
@@ -24,15 +24,10 @@ class User(
     val name: String,
 
     @Column(name = "nickname", nullable = false)
-    val nickname: String,
-
-    @OneToOne(mappedBy = "user")
-    val address: Address? = null
+    val nickname: String
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", nullable = false, unique = true)
     val id: Long? = null
-
-
 }

--- a/src/main/kotlin/com/example/sanrio/domain/user/service/AddressService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/service/AddressService.kt
@@ -1,0 +1,35 @@
+package com.example.sanrio.domain.user.service
+
+import com.example.sanrio.domain.user.dto.request.AddressRequest
+import com.example.sanrio.domain.user.repository.AddressRepository
+import com.example.sanrio.global.exception.case.InvalidValueException
+import com.example.sanrio.global.utility.Encryptor
+import com.example.sanrio.global.utility.EntityFinder
+import jakarta.transaction.Transactional
+import org.springframework.context.annotation.Description
+import org.springframework.stereotype.Service
+
+@Service
+class AddressService(
+    private val addressRepository: AddressRepository,
+    private val encryptor: Encryptor,
+    private val entityFinder: EntityFinder
+) {
+    @Description("주소 설정")
+    @Transactional
+    fun setAddress(userId: Long, request: AddressRequest) {
+        val user = entityFinder.findUserById(userId = userId)
+
+        // 우편 번호 형식 체크
+        check(request.zipCode != null && request.zipCode.length == 5) { InvalidValueException("우편번호") }
+
+        // 첫 번째로 입력한 주소라면, 해당 주소를 기본 주소로 설정한다.
+        val address =
+            if (!addressRepository.existsByUser(user = user))
+                request.to(user = user, encryptor = encryptor, isFirstAddress = true)
+            else
+                request.to(user = user, encryptor = encryptor)
+
+        addressRepository.save(address)
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #107 

## 작업 내용

- [x] Address와 User를 다대일 관계로 수정
- [x] User 엔티티 내 address 필드 삭제
- [x] Address 엔티티 내 기본 주소값을 판단하기 위한 Boolean 자료형의 필드(default) 선언
- [x] 주소를 설정하는 setAddress 메서드를 AddressService 하위로 이동

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
