### PR TITLE
[Feat] Order 엔티티에 주소 관련 필드 추가

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
@@ -17,6 +17,12 @@ class Order(
     @Column(name = "total_price", nullable = false)
     val totalPrice: Int = 0,
 
+    @Column(name = "street_address", nullable = false)
+    val streetAddress: String,
+
+    @Column(name = "detail_address", nullable = false)
+    val detailAddress: ByteArray,
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     val user: User

--- a/src/main/kotlin/com/example/sanrio/domain/user/repository/AddressRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/repository/AddressRepository.kt
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository
 interface AddressRepository : JpaRepository<Address, Long> {
     fun existsByUser(user: User): Boolean
 
-    fun findByUser(user: User): Address
+    fun findByUserAndDefault(user: User, default: Boolean): Address
 }

--- a/src/main/kotlin/com/example/sanrio/global/exception/case/EmptyAddressException.kt
+++ b/src/main/kotlin/com/example/sanrio/global/exception/case/EmptyAddressException.kt
@@ -1,0 +1,3 @@
+package com.example.sanrio.global.exception.case
+
+class EmptyAddressException : ItemException("배송지 정보가 존재하지 않습니다.")


### PR DESCRIPTION
## 연관된 이슈

- closes #109 

## 작업 내용

- [x] Order 엔티티에 streetAddress와 detailAddress 필드 추가
- [x] makeOrder 메서드에 유저의 배송지 정보가 설정되어 있는지 확인
- [x] EmptyAddressException (배송지 정보가 설정되어 있지 않은 상태에서 주문을 한 경우) 생성
- [x] 배송지 정보가 확인되면, 유저의 default 주소를 Order 엔티티에 저장

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
