### PR TITLE
[Feat] 주문 내역 조회 기능 구현

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
@@ -1,20 +1,30 @@
 package com.example.sanrio.domain.order.controller
 
+import com.example.sanrio.domain.order.model.OrderPeriod
 import com.example.sanrio.domain.order.service.OrderService
+import jdk.jfr.Description
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/orders")
 class OrderController(
     private val orderService: OrderService
 ) {
+    @Description("주문 완료")
     @PostMapping
     fun makeOrder(
         @RequestParam userId: Long // TODO : userID는 추후 UserPrincipal에서 추출한다.
     ) = orderService.makeOrder(userId = userId)
         .let { ResponseEntity.ok().body(it) }
+
+    @Description("주문 내역 조회")
+    @GetMapping
+    fun getOrders(
+        @RequestParam userId: Long, // TODO : userID는 추후 UserPrincipal에서 추출한다.
+        @RequestParam(required = false) cursorId: Long?,
+        @RequestParam(required = false) period: OrderPeriod?
+    ) = orderService.getOrders(userId = userId, cursorId = cursorId, period = period)
+        .let { ResponseEntity.ok().body(it) }
+
 }

--- a/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderDataResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderDataResponse.kt
@@ -1,0 +1,28 @@
+package com.example.sanrio.domain.order.dto.response
+
+import com.example.sanrio.domain.order.model.OrderStatus
+import java.time.LocalDateTime
+
+data class OrderDataResponse(
+    val orderId: Long,
+    val code: String,
+    val status: OrderStatus,
+    val userName: String,
+    val userAddress: String?,
+    val totalPrice: Int,
+    val createdAt: LocalDateTime,
+    val orderItems: List<OrderItemResponse>
+) {
+    companion object {
+        fun from(orderResponse: OrderResponse, orderItems: List<OrderItemResponse>) = OrderDataResponse(
+            orderId = orderResponse.orderId,
+            code = orderResponse.code,
+            status = orderResponse.status,
+            userName = orderResponse.userName,
+            userAddress = orderResponse.userAddress,
+            totalPrice = orderResponse.totalPrice,
+            createdAt = orderResponse.createdAt,
+            orderItems = orderItems
+        )
+    }
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderItemResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderItemResponse.kt
@@ -1,0 +1,7 @@
+package com.example.sanrio.domain.order.dto.response
+
+data class OrderItemResponse(
+    val productName: String,
+    val unitPrice: Int,
+    val count: Int
+)

--- a/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderResponse.kt
@@ -1,0 +1,14 @@
+package com.example.sanrio.domain.order.dto.response
+
+import com.example.sanrio.domain.order.model.OrderStatus
+import java.time.LocalDateTime
+
+data class OrderResponse(
+    val orderId: Long,
+    val code: String,
+    val status: OrderStatus,
+    val userName: String,
+    val userAddress: String,
+    val totalPrice: Int,
+    val createdAt: LocalDateTime
+)

--- a/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderSliceResponse.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/dto/response/OrderSliceResponse.kt
@@ -1,0 +1,7 @@
+package com.example.sanrio.domain.order.dto.response
+
+data class OrderSliceResponse(
+    val size: Int,
+    val numberOfElements: Int,
+    val contents: List<OrderDataResponse>
+)

--- a/src/main/kotlin/com/example/sanrio/domain/order/model/OrderPeriod.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/OrderPeriod.kt
@@ -1,0 +1,17 @@
+package com.example.sanrio.domain.order.model
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import org.apache.commons.lang3.EnumUtils
+import org.springframework.context.annotation.Description
+
+enum class OrderPeriod {
+    ONE_MONTH, THREE_MONTH, ONE_YEAR;
+
+    companion object {
+        @Description("JSON으로 입력받은 문자열을 파싱하여 ProductStatus로 변환")
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(name: String?): OrderPeriod? =
+            name?.let { EnumUtils.getEnumIgnoreCase(OrderPeriod::class.java, it.trim()) }
+    }
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepository.kt
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface OrderItemRepository : JpaRepository<OrderItem, Long>
+interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepositoryCustom.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package com.example.sanrio.domain.order.repository
+
+import com.example.sanrio.domain.order.dto.response.OrderItemResponse
+import org.springframework.stereotype.Repository
+
+@Repository
+interface OrderItemRepositoryCustom {
+    fun getOrderItems(orderId: Long): List<OrderItemResponse>
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.example.sanrio.domain.order.repository
+
+import com.example.sanrio.domain.order.dto.response.OrderItemResponse
+import com.example.sanrio.domain.order.model.QOrderItem
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Description
+import org.springframework.stereotype.Repository
+
+@Repository
+class OrderItemRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : OrderItemRepositoryCustom {
+    private val orderItem = QOrderItem.orderItem
+
+    @Description("주문 내역 하위 상품 목록 조회")
+    override fun getOrderItems(orderId: Long): MutableList<OrderItemResponse> = jpaQueryFactory.select(
+        Projections.constructor(
+            OrderItemResponse::class.java,
+            orderItem.product.name,
+            orderItem.unitPrice,
+            orderItem.count
+        )
+    ).from(orderItem)
+        .where(BooleanBuilder(orderItem.order.id.eq(orderId)))
+        .orderBy(orderItem.id.desc())
+        .fetch()
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderRepository.kt
@@ -5,4 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface OrderRepository : JpaRepository<Order, Long>
+interface OrderRepository : JpaRepository<Order, Long>, OrderRepositoryCustom

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderRepositoryCustom.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderRepositoryCustom.kt
@@ -1,0 +1,17 @@
+package com.example.sanrio.domain.order.repository
+
+import com.example.sanrio.domain.order.dto.response.OrderResponse
+import com.example.sanrio.domain.order.model.OrderPeriod
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.stereotype.Repository
+
+@Repository
+interface OrderRepositoryCustom {
+    fun getOrders(
+        pageable: Pageable,
+        userId: Long,
+        cursorId: Long?,
+        period: OrderPeriod?
+    ): Slice<OrderResponse>
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderRepositoryImpl.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderRepositoryImpl.kt
@@ -1,0 +1,93 @@
+package com.example.sanrio.domain.order.repository
+
+import com.example.sanrio.domain.order.dto.response.OrderResponse
+import com.example.sanrio.domain.order.model.OrderPeriod
+import com.example.sanrio.domain.order.model.OrderStatus
+import com.example.sanrio.domain.order.model.QOrder
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Description
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+import java.time.Period
+
+@Repository
+class OrderRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : OrderRepositoryCustom {
+    private val order = QOrder.order
+
+    @Description("주문 내역 조회")
+    override fun getOrders(
+        pageable: Pageable,
+        userId: Long,
+        cursorId: Long?,
+        period: OrderPeriod?
+    ) =
+        BooleanBuilder()
+            .let {
+                // 커서 기반 페이지네이션을 위해 cursorId 보다 작은 id의 order를 판단
+                cursorId?.let { cursorId -> it.and(order.id.lt(cursorId)) }
+                it
+            }.let {
+                // 해당 유저의 주문 내역만 조회
+                it.and(order.user.id.eq(userId))
+                it
+            }.let {
+                // PAID(결제완료), SHIPPING(배송중), DELIVERED(배송완료)인 내역만 조회
+                it.and(
+                    order.status.eq(OrderStatus.PAID)
+                        .or(order.status.eq(OrderStatus.SHIPPING))
+                        .or(order.status.eq(OrderStatus.DELIVERED))
+                )
+                it
+            }.let {
+                // period에 넘어온 값에 따른 기간 판정
+                period?.let { period ->
+                    LocalDateTime.now().let { now ->
+                        it.and(
+                            order.createdAt.between(
+                                now.minus(
+                                    when (period) {
+                                        OrderPeriod.ONE_MONTH -> Period.ofMonths(1)
+                                        OrderPeriod.THREE_MONTH -> Period.ofMonths(3)
+                                        OrderPeriod.ONE_YEAR -> Period.ofYears(1)
+                                    }
+                                ), now
+                            )
+                        )
+                    }
+                }
+                it
+            }.let { getContents(pageable = pageable, whereClause = it) }
+            .let { SliceImpl(it, pageable, hasNext(content = it, pageable = pageable)) }
+
+    @Description("페이지에 포함될 주문 데이터를 가져오는 내부 메서드")
+    private fun getContents(pageable: Pageable, whereClause: BooleanBuilder) =
+        jpaQueryFactory.select(
+            Projections.constructor(
+                OrderResponse::class.java,
+                order.id,
+                order.code,
+                order.status,
+                order.user.name,
+                order.streetAddress,
+                order.totalPrice,
+                order.createdAt
+            )
+        ).from(order)
+            .where(whereClause)
+            .limit(pageable.pageSize.toLong() + 1)
+            .orderBy(order.id.desc())
+            .fetch()
+
+    @Description("다음 데이터가 있는지 여부를 확인하는 내부 메서드")
+    private fun hasNext(content: MutableList<OrderResponse>, pageable: Pageable) =
+        (content.size > pageable.pageSize).let {
+            if (it) content.removeLast()
+            it
+        }
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #111 

## 작업 내용

- [x] OrderService와 OrderController에 getOrders 메서드 생성
- [x] QueryDsl을 사용하기 위해 Order와 OrderItem에 대한 RepositoryCustom 인터페이스와 이를 구현한 RepositoryImpl 클래스 생성
- [x] OrderRepositoryCustom에서는 주문 내역을 조회하는 getOrders 메서드를 구현
- [x] OrderItemRepositoryCustom에서는 주문 내역 하위 상품 목록을 조회하는 getOrderItems 메서드 구현
- [x] getOrders 메서드의 결과값을 가져오는 OrderResponse, getOrderItems 메서드의 결과값을 가져오는 OrderItemResponse DTO 클래스 생성
- [x] OrderResponse와 OrderItemResponse를 하나로 묶는 OrderDataResponse DTO 클래스 생성
- [x] 커서 정보(Slice)를 담기 위해 OrderSliceResponse DTO 클래스 새성
    (OrderResponse + OrderItemResponse = OrderDataResponse ---> OrderSliceResponse)

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
