### PR TITLE
[Refactor] JWT 토큰을 활용한 로그인 방식 수정

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/auth/controller/AuthController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/auth/controller/AuthController.kt
@@ -1,0 +1,24 @@
+package com.example.sanrio.domain.auth.controller
+
+import com.example.sanrio.domain.auth.service.AuthService
+import com.example.sanrio.domain.user.dto.request.LoginRequest
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.validation.Valid
+import org.springframework.context.annotation.Description
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthController(
+    private val authService: AuthService
+) {
+    @Description("로그인")
+    @PostMapping("/login")
+    fun login(
+        @Valid @RequestBody request: LoginRequest,
+        response: HttpServletResponse
+    ) = authService.login(request = request, response = response)
+        .let { ResponseEntity.ok().body(it) }
+}

--- a/src/main/kotlin/com/example/sanrio/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/auth/service/AuthService.kt
@@ -1,0 +1,42 @@
+package com.example.sanrio.domain.auth.service
+
+import com.example.sanrio.domain.user.dto.request.LoginRequest
+import com.example.sanrio.domain.user.repository.UserRepository
+import com.example.sanrio.global.exception.case.LoginException
+import com.example.sanrio.global.utility.EntityFinder
+import com.example.sanrio.global.utility.JwtProvider
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Description
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val entityFinder: EntityFinder,
+    private val jwtProvider: JwtProvider
+) {
+    @Description("로그인 시 이메일 존재 여부 체크")
+    private fun checkEmail(email: String) =
+        check(userRepository.existsByEmail(email = email)) { throw LoginException() }
+
+    @Description("로그인 시 패스워드 일치 여부 체크")
+    private fun checkPassword(userPassword: String, inputPassword: String) =
+        check(passwordEncoder.matches(inputPassword, userPassword)) { throw LoginException() }
+
+    @Description("로그인")
+    fun login(request: LoginRequest, response: HttpServletResponse) {
+        checkEmail(email = request.email)
+
+        val user = entityFinder.findUserByEmail(email = request.email)
+        checkPassword(
+            userPassword = user.password,
+            inputPassword = request.password
+        )
+
+        // JWT 토큰 생성 후 Cookie에 저장
+        val token = jwtProvider.createToken(userId = user.id!!, email = user.email, role = user.role)
+        jwtProvider.addTokenToCookie(token = token, response = response)
+    }
+}

--- a/src/main/kotlin/com/example/sanrio/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/controller/UserController.kt
@@ -39,12 +39,6 @@ class UserController(
     ) = userService.checkVerificationCode(email = email, code = code)
         .let { ResponseEntity.ok().body(it) }
 
-    @Description("로그인")
-    @PostMapping("/login")
-    fun login(
-        @Valid @RequestBody request: LoginRequest
-    ) = ResponseEntity.ok().body(userService.login(request = request))
-
     @Description("주소 설정")
     @PostMapping("/users/{userId}/address")
     fun setAddress(

--- a/src/main/kotlin/com/example/sanrio/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/service/UserService.kt
@@ -78,20 +78,4 @@ class UserService(
         check(redisTemplate.opsForValue().get(email) != null) { throw VerificationException("인증번호가 만료되었습니다.") }
         check(redisTemplate.opsForValue().get(email) == code) { throw VerificationException("인증번호가 일치하지 않습니다.") }
     }
-
-    @Description("로그인 시 이메일 존재 여부 체크")
-    private fun findUserByEmail(email: String) =
-        userRepository.findByEmail(email = email) ?: throw LoginException()
-
-    @Description("로그인 시 패스워드 일치 여부 체크")
-    private fun validatePassword(user: User, password: String) =
-        if (!passwordEncoder.matches(password, user.password)) throw LoginException() else Unit
-
-    @Description("로그인")
-    fun login(request: LoginRequest) =
-        validatePassword(
-            user = findUserByEmail(email = request.email),
-            password = request.password
-        ) // 패스워드 검증
-            .let { } // TODO : 추후 토큰을 리턴할 예정
 }

--- a/src/main/kotlin/com/example/sanrio/global/utility/EntityFinder.kt
+++ b/src/main/kotlin/com/example/sanrio/global/utility/EntityFinder.kt
@@ -30,4 +30,7 @@ class EntityFinder(
 
     fun findUserById(userId: Long) =
         userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("유저")
+
+    fun findUserByEmail(email: String) =
+        userRepository.findByEmail(email = email) ?: throw ModelNotFoundException("유저")
 }

--- a/src/test/kotlin/com/example/sanrio/domain/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/sanrio/domain/auth/controller/AuthControllerTest.kt
@@ -1,0 +1,127 @@
+package com.example.sanrio.domain.auth.controller
+
+import com.example.sanrio.domain.cart.repository.CartRepository
+import com.example.sanrio.domain.user.dto.request.LoginRequest
+import com.example.sanrio.domain.user.dto.request.SignUpRequest
+import com.example.sanrio.domain.user.repository.UserRepository
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.net.URLDecoder
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    lateinit var userRepository: UserRepository
+
+    @Autowired
+    lateinit var cartRepository: CartRepository
+
+    @Autowired
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @AfterEach
+    fun clean() {
+        cartRepository.deleteAll()
+        userRepository.deleteAll()
+    }
+
+    @Test
+    fun 정상적으로_로그인에_성공한_경우() {
+        // given
+        val user = getUser()
+        val request = LoginRequest(
+            email = "test@gmail.com",
+            password = "Test1234!"
+        )
+        val json = objectMapper.writeValueAsString(request)
+
+        // expected
+        val result = mockMvc.perform(
+            post("/login")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+        ).andExpect(status().isOk)
+            .andExpect(MockMvcResultMatchers.cookie().exists(COOKIE_NAME))
+            .andDo(print())
+            .andReturn()
+
+        val cookie = result.response.getCookie(COOKIE_NAME)
+        assertThat(cookie).isNotNull
+        assertThat(URLDecoder.decode(cookie!!.value, "UTF-8")).startsWith(BEARER_PREFIX)
+    }
+
+    private fun getUser() = SignUpRequest(
+        email = "test@gmail.com",
+        password = "Test1234!",
+        password2 = "Test1234!",
+        name = "테스트 계정"
+    ).to(passwordEncoder = passwordEncoder)
+        .let { userRepository.save(it) }
+
+    @Test
+    fun 존재하지_않는_이메일로_로그인을_시도한_경우() {
+        // given
+        val user = getUser()
+        val request = LoginRequest(
+            email = "null@gmail.com",
+            password = "Test1234!"
+        )
+        val json = objectMapper.writeValueAsString(request)
+
+        // expected
+        mockMvc.perform(
+            post("/login")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("아이디 혹은 비밀번호가 잘못되었습니다. 다시 확인해주세요."))
+            .andExpect(jsonPath("$.statusCode").value("400 Bad Request"))
+            .andDo(print())
+    }
+
+    @Test
+    fun 비밀번호가_일치하지_않는_경우() {
+        // given
+        val user = getUser()
+        val request = LoginRequest(
+            email = "test@gmail.com",
+            password = "Null1234!"
+        )
+        val json = objectMapper.writeValueAsString(request)
+
+        // expected
+        mockMvc.perform(
+            post("/login")
+                .contentType(APPLICATION_JSON)
+                .content(json)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").value("아이디 혹은 비밀번호가 잘못되었습니다. 다시 확인해주세요."))
+            .andExpect(jsonPath("$.statusCode").value("400 Bad Request"))
+            .andDo(print())
+    }
+
+    companion object {
+        private const val COOKIE_NAME = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/src/test/kotlin/com/example/sanrio/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/example/sanrio/domain/user/controller/UserControllerTest.kt
@@ -156,7 +156,7 @@ class UserControllerTest {
             email = "test@gmail.com",
             password = "Test1234!",
             password2 = "Test1234!",
-            name = ""
+            name = "테스트 계정"
         ).to(passwordEncoder = passwordEncoder)
         userRepository.save(user)
 


### PR DESCRIPTION
## 연관된 이슈

- closes #117 

## 작업 내용

- [x] login 메서드를 AuthController와 AuthService로 분리
- [x] email과 password 검증 후, JWT 토큰을 생성하여 Cookie에 담아 돌려주는 로직 구현
- [x] AuthControllerTest에 로그인 관련 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
