### PR TITLE
[Settings] 테스트 환경에서 User 인증 정보를 유지하기 위한 설정

### DIFF
--- a/src/test/kotlin/com/example/sanrio/global/auth/AuthenticationHelper.kt
+++ b/src/test/kotlin/com/example/sanrio/global/auth/AuthenticationHelper.kt
@@ -1,0 +1,12 @@
+package com.example.sanrio.global.auth
+
+import com.example.sanrio.global.jwt.UserPrincipal
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class AuthenticationHelper {
+    fun getCurrentUser() =
+        SecurityContextHolder.getContext().authentication
+            .let { authentication -> authentication.principal as UserPrincipal }
+}

--- a/src/test/kotlin/com/example/sanrio/global/auth/WithCustomMockUser.kt
+++ b/src/test/kotlin/com/example/sanrio/global/auth/WithCustomMockUser.kt
@@ -1,0 +1,7 @@
+package com.example.sanrio.global.auth
+
+import org.springframework.security.test.context.support.WithSecurityContext
+
+@Retention(AnnotationRetention.RUNTIME)
+@WithSecurityContext(factory = WithAccountSecurityContextFactory::class)
+annotation class WithCustomMockUser

--- a/src/test/kotlin/com/example/sanrio/global/auth/WithCustomMockUserSecurityContextFactory.kt
+++ b/src/test/kotlin/com/example/sanrio/global/auth/WithCustomMockUserSecurityContextFactory.kt
@@ -1,0 +1,44 @@
+package com.example.sanrio.global.auth
+
+import com.example.sanrio.domain.user.dto.request.SignUpRequest
+import com.example.sanrio.domain.user.repository.UserRepository
+import com.example.sanrio.global.jwt.JwtAuthenticationToken
+import com.example.sanrio.global.jwt.UserPrincipal
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
+
+class WithAccountSecurityContextFactory(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val httpServletRequest: HttpServletRequest
+) : WithSecurityContextFactory<WithCustomMockUser> {
+
+    override fun createSecurityContext(annotation: WithCustomMockUser): SecurityContext {
+        val user = SignUpRequest(
+            email = "test@gmail.com",
+            password = "Test1234!",
+            password2 = "Test1234!",
+            name = "테스트 계정"
+        ).to(passwordEncoder = passwordEncoder)
+            .let { userRepository.save(it) }
+
+        val principal = UserPrincipal(
+            id = user.id!!,
+            email = user.email,
+            roles = setOf(user.role.authority)
+        )
+
+        val authentication = JwtAuthenticationToken(
+            principal = principal,
+            details = WebAuthenticationDetailsSource().buildDetails(httpServletRequest)
+        )
+        val context = SecurityContextHolder.createEmptyContext()
+        context.authentication = authentication
+
+        return context
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #121 

## 작업 내용

- [x] 테스트 시 User 인증 정보를 설정하기 위한 WithCustomMockUser 어노테이션 클래스 생성
- [x] SecurityContext를 생성하는 WithAccountSecurityContextFactory 팩토리 클래스 생성
- [x] 현재 로그인한 사용자의 정보를 가져오는 AuthenticationHelper 클래스 생성

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
