### PR TITLE
[Feat] 관리자가 주문 취소 신청을 승인하는 기능 구현

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
@@ -5,6 +5,7 @@ import com.example.sanrio.domain.order.service.OrderService
 import com.example.sanrio.global.jwt.UserPrincipal
 import org.springframework.context.annotation.Description
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
@@ -37,4 +38,12 @@ class OrderController(
     ) = orderService.cancelOrder(userId = userPrincipal.id, orderId = orderId)
         .let { ResponseEntity.ok().body(it) }
 
+    @Description("주문 취소 신청 승인")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/cancel/{orderId}")
+    fun acceptCancelOrder(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable orderId: Long,
+    ) = orderService.acceptCancelOrder(userId = userPrincipal.id, orderId = orderId)
+        .let { ResponseEntity.ok().body(it) }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/OrderItemRepository.kt
@@ -1,8 +1,11 @@
 package com.example.sanrio.domain.order.repository
 
+import com.example.sanrio.domain.order.model.Order
 import com.example.sanrio.domain.order.model.OrderItem
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom
+interface OrderItemRepository : JpaRepository<OrderItem, Long>, OrderItemRepositoryCustom {
+    fun findByOrder(order: Order): List<OrderItem>
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/service/OrderService.kt
@@ -130,6 +130,19 @@ class OrderService(
         order.updateStatus(status = OrderStatus.REQUESTED_FOR_CANCEL)
     }
 
+    @Description("주문 취소 신청 승인")
+    @Transactional
+    fun acceptCancelOrder(userId: Long, orderId: Long) {
+        val order = entityFinder.findOrderById(orderId = orderId)
+
+        // 재고 수량 복구
+        orderItemRepository.findByOrder(order = order)
+            .forEach { orderItem -> orderItem.product.increaseStock(count = orderItem.count) }
+
+        // 취소 완료
+        order.updateStatus(status = OrderStatus.CANCELLED)
+    }
+
     companion object {
         private const val ORDER_PAGE_SIZE = 5
     }

--- a/src/main/kotlin/com/example/sanrio/domain/product/model/Product.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/product/model/Product.kt
@@ -37,4 +37,10 @@ class Product(
         this.stock -= count
         if (this.stock == 0) this.status = ProductStatus.SOLD_OUT
     }
+
+    @Description("재고 수량 증가")
+    fun increaseStock(count: Int) {
+        this.stock += count
+        if (this.status == ProductStatus.SOLD_OUT && this.stock > 0) this.status = ProductStatus.SALE
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #128 

## 작업 내용

- [x] OrderService와 OrderController에 acceptCancelOrder 메서드 생성
- [x] OrderControllerTest에 주문 취소 신청 관련 테스트 코드 추가
- [x] Product에 재고 수량을 증가시키는 increaseStock 메서드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
