### PR TITLE
[Feat] 로그인 성공 시 AccessToken과 RefreshToken을 헤더에 담아 리턴

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/auth/service/AuthService.kt
@@ -36,7 +36,10 @@ class AuthService(
         )
 
         // JWT 토큰 생성 후 Cookie에 저장
-        val token = jwtProvider.createToken(userId = user.id!!, email = user.email, role = user.role)
-        jwtProvider.addTokenToCookie(token = token, response = response)
+        val accessToken = jwtProvider.getAccessToken(userId = user.id!!, email = user.email, role = user.role)
+        val refreshToken = jwtProvider.getRefreshToken(userId = user.id, email = user.email, role = user.role)
+
+        jwtProvider.addTokenToCookie(token = accessToken, response = response, type = "atk")
+        jwtProvider.addTokenToCookie(token = refreshToken, response = response, type = "rtk")
     }
 }

--- a/src/main/kotlin/com/example/sanrio/global/exception/case/JwtTokenException.kt
+++ b/src/main/kotlin/com/example/sanrio/global/exception/case/JwtTokenException.kt
@@ -1,3 +1,3 @@
 package com.example.sanrio.global.exception.case
 
-class JwtTokenException : RuntimeException("유효하지 않은 JWT 토큰입니다.")
+class JwtTokenException(message: String = "유효하지 않은 JWT 토큰입니다.") : RuntimeException(message)

--- a/src/test/kotlin/com/example/sanrio/domain/auth/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/example/sanrio/domain/auth/controller/AuthControllerTest.kt
@@ -61,13 +61,18 @@ class AuthControllerTest {
                 .contentType(APPLICATION_JSON)
                 .content(json)
         ).andExpect(status().isOk)
-            .andExpect(MockMvcResultMatchers.cookie().exists(COOKIE_NAME))
+            .andExpect(MockMvcResultMatchers.cookie().exists(COOKIE_NAME_ATK))
+            .andExpect(MockMvcResultMatchers.cookie().exists(COOKIE_NAME_RTK))
             .andDo(print())
             .andReturn()
 
-        val cookie = result.response.getCookie(COOKIE_NAME)
-        assertThat(cookie).isNotNull
-        assertThat(URLDecoder.decode(cookie!!.value, "UTF-8")).startsWith(BEARER_PREFIX)
+        val cookieAtk = result.response.getCookie(COOKIE_NAME_ATK)
+        assertThat(cookieAtk).isNotNull
+        assertThat(URLDecoder.decode(cookieAtk!!.value, "UTF-8")).startsWith(BEARER_PREFIX)
+
+        val cookieRtk = result.response.getCookie(COOKIE_NAME_RTK)
+        assertThat(cookieRtk).isNotNull
+        assertThat(URLDecoder.decode(cookieRtk!!.value, "UTF-8")).startsWith(BEARER_PREFIX)
     }
 
     private fun getUser() = SignUpRequest(
@@ -121,7 +126,8 @@ class AuthControllerTest {
     }
 
     companion object {
-        private const val COOKIE_NAME = "Authorization"
+        private const val COOKIE_NAME_ATK = "AccessToken"
+        private const val COOKIE_NAME_RTK = "RefreshToken"
         private const val BEARER_PREFIX = "Bearer "
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- closes #134 

## 작업 내용

- [x] JwtProvider에 ATK와 RTK를 생성하는 getAccessToken, getRefreshToken 메서드 생성
- [x] JwtAuthenticationFilter에서 RefreshToken도 검증하는 로직 추가
- [x] ExpiredJwtException가 발생한 경우 JwtTokenException을 throw하며 재로그인 요청 메세지를 전달
- [x] AuthControllerTest에 로그인 관련 코드 수정

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
