### PR TITLE
[Feat] Order 엔티티에 orderRequest, usedPoint 필드 추가

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
@@ -1,5 +1,6 @@
 package com.example.sanrio.domain.order.controller
 
+import com.example.sanrio.domain.order.dto.request.OrderRequest
 import com.example.sanrio.domain.order.model.OrderPeriod
 import com.example.sanrio.domain.order.service.OrderService
 import com.example.sanrio.global.jwt.UserPrincipal
@@ -14,11 +15,12 @@ import org.springframework.web.bind.annotation.*
 class OrderController(
     private val orderService: OrderService
 ) {
-    @Description("주문 완료")
+    @Description("주문 진행")
     @PostMapping
     fun makeOrder(
-        @AuthenticationPrincipal userPrincipal: UserPrincipal
-    ) = orderService.makeOrder(userId = userPrincipal.id)
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @RequestBody request: OrderRequest?
+    ) = orderService.makeOrder(userId = userPrincipal.id, request = request)
         .let { ResponseEntity.ok().body(it) }
 
     @Description("주문 내역 조회")

--- a/src/main/kotlin/com/example/sanrio/domain/order/dto/request/OrderRequest.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/dto/request/OrderRequest.kt
@@ -1,0 +1,6 @@
+package com.example.sanrio.domain.order.dto.request
+
+data class OrderRequest(
+    val point: Int?,
+    val request: String?
+)

--- a/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
@@ -16,13 +16,19 @@ class Order(
     var status: OrderStatus = OrderStatus.PAID,
 
     @Column(name = "total_price", nullable = false)
-    val totalPrice: Int = 0,
+    val totalPrice: Int,
 
     @Column(name = "street_address", nullable = false)
     val streetAddress: String,
 
     @Column(name = "detail_address", nullable = false)
     val detailAddress: ByteArray,
+
+    @Column(name = "order_request", nullable = false)
+    val orderRequest: String,
+
+    @Column(name = "used_point", nullable = true)
+    val usedPoint: Int?,
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/kotlin/com/example/sanrio/domain/user/model/User.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/user/model/User.kt
@@ -2,6 +2,7 @@ package com.example.sanrio.domain.user.model
 
 import com.example.sanrio.global.model.BaseEntity
 import jakarta.persistence.*
+import org.springframework.context.annotation.Description
 
 @Entity
 @Table(name = "users")
@@ -30,10 +31,15 @@ class User(
     val phone: String,
 
     @Column(name = "point", nullable = false)
-    val point: Int = 0
+    var point: Int = 0
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", nullable = false, unique = true)
     val id: Long? = null
+
+    @Description("주문이 배송완료가 되면, 주문 금액의 1%가 유저의 포인트로 적립됨")
+    fun updatePoint(point: Int) {
+        this.point += point
+    }
 }

--- a/src/main/kotlin/com/example/sanrio/global/jwt/AuthenticationHelper.kt
+++ b/src/main/kotlin/com/example/sanrio/global/jwt/AuthenticationHelper.kt
@@ -1,6 +1,5 @@
-package com.example.sanrio.global.auth
+package com.example.sanrio.global.jwt
 
-import com.example.sanrio.global.jwt.UserPrincipal
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 

--- a/src/test/kotlin/com/example/sanrio/domain/address/controller/AddressControllerTest.kt
+++ b/src/test/kotlin/com/example/sanrio/domain/address/controller/AddressControllerTest.kt
@@ -6,7 +6,7 @@ import com.example.sanrio.domain.address.repository.AddressRepository
 import com.example.sanrio.domain.cart.repository.CartRepository
 import com.example.sanrio.domain.user.model.User
 import com.example.sanrio.domain.user.repository.UserRepository
-import com.example.sanrio.global.auth.AuthenticationHelper
+import com.example.sanrio.global.jwt.AuthenticationHelper
 import com.example.sanrio.global.auth.WithCustomMockUser
 import com.example.sanrio.global.utility.Encryptor
 import com.example.sanrio.global.utility.EntityFinder

--- a/src/test/kotlin/com/example/sanrio/domain/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/example/sanrio/domain/user/controller/UserControllerTest.kt
@@ -4,7 +4,7 @@ import com.example.sanrio.domain.cart.repository.CartRepository
 import com.example.sanrio.domain.user.dto.request.SignUpRequest
 import com.example.sanrio.domain.user.model.User
 import com.example.sanrio.domain.user.repository.UserRepository
-import com.example.sanrio.global.auth.AuthenticationHelper
+import com.example.sanrio.global.jwt.AuthenticationHelper
 import com.example.sanrio.global.auth.WithCustomMockUser
 import com.example.sanrio.global.utility.EntityFinder
 import com.example.sanrio.global.utility.NicknameGenerator.generateNickname

--- a/src/test/kotlin/com/example/sanrio/global/auth/WithCustomMockUserSecurityContextFactory.kt
+++ b/src/test/kotlin/com/example/sanrio/global/auth/WithCustomMockUserSecurityContextFactory.kt
@@ -24,7 +24,8 @@ class WithAccountSecurityContextFactory(
             password = "Test1234!",
             name = "테스트 계정",
             nickname = generateNickname(),
-            phone = "010-1234-5678"
+            phone = "010-1234-5678",
+            point = 10000
         ).let { userRepository.save(it) }
 
         val principal = UserPrincipal(


### PR DESCRIPTION
## 연관된 이슈

- closes #150 

## 작업 내용

- [x] Order 엔티티에 orderRequest, usedPoint 필드 추가 및 관련 코드 수정
- [x] 주문 요청 사항과 사용할 적립금 정보를 담는 OrderRequest DTO 객체 생성
- [x] OrderController에서 OrderRequest를 nullable하게 받도록 지정
- [x] 주문을 진행하는 makeOrder 메서드에 포인트를 차감하는 로직 추가
- [x] 주문 취소 신청을 승인하는 acceptCancelOrder 메서드에 포인트 복구 로직 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
