### PR TITLE
[Refactor] 주문이 완료되는 즉시 유저 포인트가 적립되는 정책으로 변경

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/service/OrderService.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/service/OrderService.kt
@@ -93,9 +93,12 @@ class OrderService(
                 .let { orderItem -> orderItemRepository.save(orderItem) }
         }
 
-        // 포인트 차감
+        // 포인트 적립 - 사용한 포인트
         if (request?.point != null)
-            user.updatePoint(point = (request.point * (-1)))
+            user.updatePoint(point = (cart.totalPrice * 0.02).toInt() + (request.point * (-1)))
+        // 포인트 적립
+        else
+            user.updatePoint(point = (cart.totalPrice * 0.02).toInt())
 
         // 장바구니 리셋
         resetCart(cart = cart)
@@ -154,8 +157,11 @@ class OrderService(
         orderItemRepository.findByOrder(order = order)
             .forEach { orderItem -> orderItem.product.increaseStock(count = orderItem.count) }
 
-        // 포인트 복구
+        // 사용한 포인트 복구
         user.updatePoint(point = order.usedPoint ?: 0)
+
+        // 적립된 포인트 복구
+        user.updatePoint(point = (order.totalPrice * 0.02).toInt() * (-1))
 
         // 취소 완료
         order.updateStatus(status = OrderStatus.CANCELLED)

--- a/src/main/kotlin/com/example/sanrio/global/scheduled/OrderScheduleService.kt
+++ b/src/main/kotlin/com/example/sanrio/global/scheduled/OrderScheduleService.kt
@@ -77,10 +77,6 @@ class OrderScheduleService(
                 val order = entityFinder.findOrderById(orderId = orderId)
                 order.updateStatus(OrderStatus.DELIVERED)
 
-                // 포인트 적립
-                val user = entityFinder.findUserById(authenticationHelper.getCurrentUser().id)
-                user.updatePoint(point = (order.totalPrice * 0.02).toInt())
-
                 // Redis 캐시 삭제
                 redisTemplate.delete("order_shipping_${orderId}")
             }


### PR DESCRIPTION
## 연관된 이슈

- closes #152 

## 작업 내용

- [x] 기존 OrderScheduleService의 배송 완료 후 유저 포인트 적립 로직 삭제
- [x] OrderService의 makeOrder 메서드에서 주문 완료 후 유저 포인트 적립 로직 구현
- [x] OrderService의 acceptCancelOrder에서 적립된 포인트 복구 로직 구현
- [x] OrderControllerTest에서 적립 포인트 관련 테스트 코드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
