### PR TITLE
[Feat] AuthenticationEntryPoint를 구현하여 인증 관련 예외 처리 및 ErrorResponse 리턴

### DIFF
--- a/src/main/kotlin/com/example/sanrio/global/jwt/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/example/sanrio/global/jwt/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,35 @@
+package com.example.sanrio.global.jwt
+
+import com.example.sanrio.global.exception.ErrorResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class CustomAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val json = objectMapper.writeValueAsString(
+            ErrorResponse(
+                message = "인증되지 않은 접근입니다. 로그인 후 다시 시도해주세요.",
+                statusCode = "401 UNAUTHORIZED",
+                time = LocalDateTime.now()
+            )
+        )
+        response.writer.write(json)
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- closes #156 

## 작업 내용

- [x] AuthenticationEntryPoint를 구현하여 인증 관련 예외를 처리하고 ErrorResponse를 리턴하는 기능 구현
- [x] SecurityConfig에 CustomAuthenticationEntryPoint 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
