### PR TITLE
[Feat] 반품 기록을 저장하기 위한 Recall 엔티티 생성

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/model/Recall.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/Recall.kt
@@ -1,0 +1,27 @@
+package com.example.sanrio.domain.order.model
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "recalls")
+class Recall(
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    val reason: RecallReason,
+
+    @Column(name = "detail", nullable = false)
+    val detail: String?,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @OneToOne
+    @JoinColumn(name = "order_id", nullable = false)
+    val order: Order
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recall_id", nullable = false, unique = true)
+    val id: Long? = null
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/model/RecallReason.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/RecallReason.kt
@@ -1,0 +1,5 @@
+package com.example.sanrio.domain.order.model
+
+enum class RecallReason {
+    PERSONAL, INCORRECT_SIZE, DEFECTIVE, UNSATISFACTORY_DESIGN, ETC
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/RecallRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/RecallRepository.kt
@@ -1,0 +1,8 @@
+package com.example.sanrio.domain.order.repository
+
+import com.example.sanrio.domain.order.model.Recall
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RecallRepository : JpaRepository<Recall, Long>


### PR DESCRIPTION
## 연관된 이슈

- closes #166 

## 작업 내용

- [x] Recall 엔티티 생성 -> id, reason, detail, createdAt, order
- [x] 반품 사유를 선택하기 위한 RecallReason enum 클래스 생성
- [x] RecallRepository 생성

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
