### PR TITLE
[Feat] 반품 신청 기능 구현

### DIFF
--- a/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/controller/OrderController.kt
@@ -1,9 +1,11 @@
 package com.example.sanrio.domain.order.controller
 
 import com.example.sanrio.domain.order.dto.request.OrderRequest
+import com.example.sanrio.domain.order.dto.request.RecallRequest
 import com.example.sanrio.domain.order.model.OrderPeriod
 import com.example.sanrio.domain.order.service.OrderService
 import com.example.sanrio.global.jwt.UserPrincipal
+import jakarta.validation.Valid
 import org.springframework.context.annotation.Description
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
@@ -33,7 +35,7 @@ class OrderController(
         .let { ResponseEntity.ok().body(it) }
 
     @Description("주문 취소 신청")
-    @GetMapping("/cancel/{orderId}")
+    @GetMapping("/{orderId}/cancel")
     fun cancelOrder(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable orderId: Long
@@ -42,10 +44,19 @@ class OrderController(
 
     @Description("주문 취소 신청 승인")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("/cancel/{orderId}")
+    @PutMapping("/{orderId}/cancel")
     fun acceptCancelOrder(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable orderId: Long,
     ) = orderService.acceptCancelOrder(userId = userPrincipal.id, orderId = orderId)
+        .let { ResponseEntity.ok().body(it) }
+
+    @Description("반품 신청")
+    @PostMapping("/{orderId}/recall")
+    fun recallOrder(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        @PathVariable orderId: Long,
+        @Valid @RequestBody request: RecallRequest
+    ) = orderService.recallOrder(userId = userPrincipal.id, orderId = orderId, request = request)
         .let { ResponseEntity.ok().body(it) }
 }

--- a/src/main/kotlin/com/example/sanrio/domain/order/dto/request/RecallRequest.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/dto/request/RecallRequest.kt
@@ -1,0 +1,19 @@
+package com.example.sanrio.domain.order.dto.request
+
+import com.example.sanrio.domain.order.model.Order
+import com.example.sanrio.domain.order.model.Recall
+import com.example.sanrio.domain.order.model.RecallReason
+import jakarta.validation.constraints.NotBlank
+
+data class RecallRequest(
+    @field:NotBlank(message = "반품 사유를 선택해주세요.")
+    val reason: String?,
+
+    val detail: String?
+) {
+    fun to(order: Order) = Recall(
+        reason = RecallReason.valueOf(this.reason!!),
+        detail = this.detail,
+        order = order
+    )
+}

--- a/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/model/Order.kt
@@ -5,6 +5,11 @@ import com.example.sanrio.global.model.BaseEntity
 import jakarta.persistence.*
 import org.springframework.context.annotation.Description
 
+/**
+[중요 사항]
+Order 객체에서 수정될 수 있는 값은 오직 status 뿐이다.
+ */
+
 @Entity
 @Table(name = "orders")
 class Order(
@@ -28,7 +33,7 @@ class Order(
     val orderRequest: String,
 
     @Column(name = "used_point", nullable = true)
-    val usedPoint: Int?,
+    val usedPoint: Int? = null,
 
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/kotlin/com/example/sanrio/domain/order/repository/RecallRepository.kt
+++ b/src/main/kotlin/com/example/sanrio/domain/order/repository/RecallRepository.kt
@@ -1,8 +1,11 @@
 package com.example.sanrio.domain.order.repository
 
+import com.example.sanrio.domain.order.model.Order
 import com.example.sanrio.domain.order.model.Recall
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface RecallRepository : JpaRepository<Recall, Long>
+interface RecallRepository : JpaRepository<Recall, Long> {
+    fun findByOrder(order: Order): Recall?
+}

--- a/src/main/kotlin/com/example/sanrio/global/utility/EntityFinder.kt
+++ b/src/main/kotlin/com/example/sanrio/global/utility/EntityFinder.kt
@@ -5,6 +5,7 @@ import com.example.sanrio.domain.cart.model.Cart
 import com.example.sanrio.domain.cart.repository.CartItemRepository
 import com.example.sanrio.domain.cart.repository.CartRepository
 import com.example.sanrio.domain.order.repository.OrderRepository
+import com.example.sanrio.domain.order.repository.RecallRepository
 import com.example.sanrio.domain.product.model.Product
 import com.example.sanrio.domain.product.repository.ProductRepository
 import com.example.sanrio.domain.user.model.User
@@ -20,7 +21,8 @@ class EntityFinder(
     private val productRepository: ProductRepository,
     private val cartRepository: CartRepository,
     private val cartItemRepository: CartItemRepository,
-    private val orderRepository: OrderRepository
+    private val orderRepository: OrderRepository,
+    private val recallRepository: RecallRepository
 ) {
     fun findProductById(productId: Long) =
         productRepository.findByIdOrNull(productId) ?: throw ModelNotFoundException("상품")
@@ -34,6 +36,9 @@ class EntityFinder(
 
     fun findOrderById(orderId: Long) =
         orderRepository.findByIdOrNull(orderId) ?: throw ModelNotFoundException("주문")
+
+    fun findRecallByOrderId(orderId: Long) =
+        recallRepository.findByOrder(order = findOrderById(orderId = orderId)) ?: throw ModelNotFoundException("반품")
 
     fun findUserById(userId: Long) =
         userRepository.findByIdOrNull(userId) ?: throw ModelNotFoundException("유저")


### PR DESCRIPTION
## 연관된 이슈

- closes #168 

## 작업 내용

- [x] OrderService와 OrderController에 recallOrder 메서드 추가
- [x] 반품 관련 사용자 입력값을 담을 RecallRequest DTO 클래스 생성
- [x] OrderControllerTest에 반품 신청 관련 테스트 코드 추가
- [x] EntityFinder에 orderId로 Recall 객체를 찾는 findRecallByOrderId 메서드 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
