### PR TITLE
[Hotfix] 각 테스트 메서드 내에 토큰을 만들어 쿠키에 넣어주는 로직을 추가

### DIFF
--- a/src/test/kotlin/com/example/sanrio/domain/order/controller/OrderControllerTest.kt
+++ b/src/test/kotlin/com/example/sanrio/domain/order/controller/OrderControllerTest.kt
@@ -105,7 +105,6 @@ class OrderControllerTest {
         productRepository.deleteAll()
         addressRepository.deleteAll()
         userRepository.deleteAll()
-
         jwtProvider.deleteCookie(response = response)
     }
 


### PR DESCRIPTION
## 연관된 이슈

- closes #170 

## 작업 내용

- [x] 각 테스트 메서드 내에서 AccessToken과 RefreshToken을 만들어 쿠키에 넣어주는 로직을 추가

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!
